### PR TITLE
feat: splash screen 기본 구현(아직 디자인이 없어서 임시 스크린 구현)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,9 @@ insert_final_newline = true
 #최대 길이 150으로 설정
 max_line_length = 150
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
-ktlint_code_stype=android_studio
+ktlint_code_style = intellij_idea
+ij_any_class_annotation_wrap = off
+#클래스에 어노테이션이 있을 경우 한칸 내리는 상황 제거
+ktlint_standard_annotation = disabled
+ij_c_class_constructor_init_list_align_multiline = false
 ktlint_function_naming_ignore_when_annotated_with=Composable

--- a/app/src/main/java/com/core/yongproject/App.kt
+++ b/app/src/main/java/com/core/yongproject/App.kt
@@ -2,7 +2,7 @@ package com.core.yongproject
 
 import android.app.Application
 import com.kakao.sdk.common.KakaoSdk
-import com.youth.app.com.youth.yongproject.app.BuildConfig
+import com.youth.app.yongproject.BuildConfig
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -24,4 +24,7 @@ dependencies {
     implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp3.okhttp)
     implementation(libs.logging.interceptor)
+
+    implementation(libs.androidx.datastore.preferences.core)
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/core/data/src/main/java/com/youthtalk/data/LoginService.kt
+++ b/core/data/src/main/java/com/youthtalk/data/LoginService.kt
@@ -8,7 +8,5 @@ import retrofit2.http.POST
 
 interface LoginService {
     @POST("/login")
-    suspend fun postLogin(
-        @Body requestBody: RequestBody,
-    ): CommonResponse<TokenResponse>
+    suspend fun postLogin(@Body requestBody: RequestBody): CommonResponse<TokenResponse>
 }

--- a/core/data/src/main/java/com/youthtalk/di/ApiModule.kt
+++ b/core/data/src/main/java/com/youthtalk/di/ApiModule.kt
@@ -1,5 +1,9 @@
 package com.youthtalk.di
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
 import com.youth.app.core.data.BuildConfig
 import com.youthtalk.data.LoginService
@@ -8,6 +12,7 @@ import com.youthtalk.model.TokenResponse
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -20,6 +25,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object ApiModule {
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "youths")
+
     @Provides
     @Singleton
     fun provideOkHttp(): OkHttpClient {
@@ -75,4 +82,8 @@ object ApiModule {
     @Provides
     @Singleton
     fun provideLoginService(retrofit: Retrofit): LoginService = retrofit.create(LoginService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> = context.dataStore
 }

--- a/core/data/src/main/java/com/youthtalk/di/DataModule.kt
+++ b/core/data/src/main/java/com/youthtalk/di/DataModule.kt
@@ -1,6 +1,8 @@
 package com.youthtalk.di
 
+import com.core.dataapi.repository.DataStoreRepository
 import com.core.dataapi.repository.LoginRepository
+import com.youthtalk.repository.DataStoreRepositoryImpl
 import com.youthtalk.repository.LoginRepositoryImpl
 import dagger.Binds
 import dagger.Module
@@ -12,4 +14,7 @@ import dagger.hilt.components.SingletonComponent
 abstract class DataModule {
     @Binds
     abstract fun bindsLoginRepository(repository: LoginRepositoryImpl): LoginRepository
+
+    @Binds
+    abstract fun bindsDataStoreRepository(repository: DataStoreRepositoryImpl): DataStoreRepository
 }

--- a/core/data/src/main/java/com/youthtalk/mapper/LoginTokenMapper.kt
+++ b/core/data/src/main/java/com/youthtalk/mapper/LoginTokenMapper.kt
@@ -3,8 +3,7 @@ package com.youthtalk.mapper
 import com.youthtalk.model.Token
 import com.youthtalk.model.TokenResponse
 
-fun TokenResponse.toData(): Token =
-    Token(
-        this.accessToken,
-        this.refreshToken,
-    )
+fun TokenResponse.toData(): Token = Token(
+    this.accessToken,
+    this.refreshToken,
+)

--- a/core/data/src/main/java/com/youthtalk/repository/DataStoreRepositoryImpl.kt
+++ b/core/data/src/main/java/com/youthtalk/repository/DataStoreRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.youthtalk.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.core.dataapi.repository.DataStoreRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class DataStoreRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : DataStoreRepository {
+    companion object {
+        const val ACCESS_TOKEN = "ACCESS_TOKEN"
+        const val REFRESH_TOKEN = "REFRESH_TOKEN"
+    }
+
+    override fun hasToken(): Flow<Boolean> = flow {
+        val accessToken = stringPreferencesKey(ACCESS_TOKEN)
+        val refreshToken = stringPreferencesKey(REFRESH_TOKEN)
+        dataStore.data.map { preferences ->
+            preferences[accessToken] != null && preferences[refreshToken] != null
+        }.collect { emit(it) }
+    }
+}

--- a/core/data/src/main/java/com/youthtalk/repository/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/youthtalk/repository/LoginRepositoryImpl.kt
@@ -14,30 +14,27 @@ import kotlinx.coroutines.flow.flow
 import retrofit2.HttpException
 import javax.inject.Inject
 
-class LoginRepositoryImpl
-    @Inject
-    constructor(
-        private val loginService: LoginService,
-    ) : LoginRepository {
-        override fun postLogin(userId: String): Flow<Token> =
-            flow {
-                runCatching { loginService.postLogin(LoginRequest(userId).toRequestBody()) }
-                    .onSuccess { token ->
-                        Log.d("YOON-CHAN", "success $token")
-                        emit(token.data.toData())
-                    }
-                    .onFailure { error ->
-                        when (error) {
-                            is HttpException -> {
-                                val e = Gson().fromJson(error.response()?.errorBody()?.string(), CommonResponse::class.java)
+class LoginRepositoryImpl @Inject constructor(
+    private val loginService: LoginService,
+) : LoginRepository {
+    override fun postLogin(userId: String): Flow<Token> = flow {
+        runCatching { loginService.postLogin(LoginRequest(userId).toRequestBody()) }
+            .onSuccess { token ->
+                Log.d("YOON-CHAN", "success $token")
+                emit(token.data.toData())
+            }
+            .onFailure { error ->
+                when (error) {
+                    is HttpException -> {
+                        val e = Gson().fromJson(error.response()?.errorBody()?.string(), CommonResponse::class.java)
 
-                                when (e.status) {
-                                    401 -> throw UnAuthorizedException(e.message)
-                                }
-                                Log.d("YOON-CHAN", "retrofit2 failure error body")
-                                Log.d("YOON-CHAN", "status ${e.status}, code ${e.code}, message ${e.message}, data ${e.data}")
-                            }
+                        when (e.status) {
+                            401 -> throw UnAuthorizedException(e.message)
                         }
+                        Log.d("YOON-CHAN", "retrofit2 failure error body")
+                        Log.d("YOON-CHAN", "status ${e.status}, code ${e.code}, message ${e.message}, data ${e.data}")
                     }
+                }
             }
     }
+}

--- a/core/dataApi/src/main/java/com/core/dataapi/repository/DataStoreRepository.kt
+++ b/core/dataApi/src/main/java/com/core/dataapi/repository/DataStoreRepository.kt
@@ -1,0 +1,7 @@
+package com.core.dataapi.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface DataStoreRepository {
+    fun hasToken(): Flow<Boolean>
+}

--- a/core/designsystem/src/main/java/com/youthtalk/designsystem/Theme.kt
+++ b/core/designsystem/src/main/java/com/youthtalk/designsystem/Theme.kt
@@ -45,10 +45,7 @@ private val LightColorScheme =
     )
 
 @Composable
-fun YongProjectTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable () -> Unit,
-) {
+fun YongProjectTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
     val colorScheme =
         when {
             darkTheme -> DarkColorScheme

--- a/core/designsystem/src/main/java/com/youthtalk/designsystem/Type.kt
+++ b/core/designsystem/src/main/java/com/youthtalk/designsystem/Type.kt
@@ -21,74 +21,74 @@ val preTendFont =
 val Typography =
     Typography(
         bodyLarge =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.Normal,
-                fontSize = 16.sp,
-                lineHeight = 24.sp,
-                letterSpacing = 0.5.sp,
-                color = Color.Black,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.Normal,
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            letterSpacing = 0.5.sp,
+            color = Color.Black,
+        ),
         bodyMedium =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.Normal,
-                fontSize = 14.sp,
-                lineHeight = 20.sp,
-                letterSpacing = 0.5.sp,
-                color = Color.Black,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.Normal,
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+            letterSpacing = 0.5.sp,
+            color = Color.Black,
+        ),
         bodySmall =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.Normal,
-                fontSize = 12.sp,
-                lineHeight = 16.sp,
-                letterSpacing = 0.5.sp,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.Normal,
+            fontSize = 12.sp,
+            lineHeight = 16.sp,
+            letterSpacing = 0.5.sp,
+        ),
         titleLarge =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.W400,
-                fontSize = 28.sp,
-                lineHeight = 44.sp,
-                letterSpacing = 0.5.sp,
-                color = Color.Black,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.W400,
+            fontSize = 28.sp,
+            lineHeight = 44.sp,
+            letterSpacing = 0.5.sp,
+            color = Color.Black,
+        ),
         titleMedium =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.Normal,
-                fontSize = 24.sp,
-                lineHeight = 32.sp,
-                letterSpacing = 0.5.sp,
-                color = Color.Black,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.Normal,
+            fontSize = 24.sp,
+            lineHeight = 32.sp,
+            letterSpacing = 0.5.sp,
+            color = Color.Black,
+        ),
         titleSmall =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.Normal,
-                fontSize = 20.sp,
-                lineHeight = 32.sp,
-                letterSpacing = 0.5.sp,
-                color = Color.Black,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.Normal,
+            fontSize = 20.sp,
+            lineHeight = 32.sp,
+            letterSpacing = 0.5.sp,
+            color = Color.Black,
+        ),
         displayLarge =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.Normal,
-                fontSize = 18.sp,
-                lineHeight = 24.sp,
-                letterSpacing = 0.5.sp,
-                color = Color.Black,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.Normal,
+            fontSize = 18.sp,
+            lineHeight = 24.sp,
+            letterSpacing = 0.5.sp,
+            color = Color.Black,
+        ),
         displayMedium =
-            TextStyle(
-                fontFamily = preTendFont,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 16.sp,
-                lineHeight = 24.sp,
-                letterSpacing = 0.5.sp,
-                color = Color.Black,
-            ),
+        TextStyle(
+            fontFamily = preTendFont,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            letterSpacing = 0.5.sp,
+            color = Color.Black,
+        ),
     )

--- a/core/domain/src/main/java/com/core/domain/usercase/CheckTokenUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/usercase/CheckTokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.core.domain.usercase
+
+import com.core.dataapi.repository.DataStoreRepository
+import javax.inject.Inject
+
+class CheckTokenUseCase @Inject constructor(
+    private val dataStoreRepository: DataStoreRepository,
+) {
+    operator fun invoke() = dataStoreRepository.hasToken()
+}

--- a/core/domain/src/main/java/com/core/domain/usercase/PostLoginUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/usercase/PostLoginUseCase.kt
@@ -3,10 +3,8 @@ package com.core.domain.usercase
 import com.core.dataapi.repository.LoginRepository
 import javax.inject.Inject
 
-class PostLoginUseCase
-    @Inject
-    constructor(
-        private val loginRepository: LoginRepository,
-    ) {
-        operator fun invoke(userId: String) = loginRepository.postLogin(userId)
-    }
+class PostLoginUseCase @Inject constructor(
+    private val loginRepository: LoginRepository,
+) {
+    operator fun invoke(userId: String) = loginRepository.postLogin(userId)
+}

--- a/core/domain/src/main/java/com/core/domain/usercase/di/UseCaseModule.kt
+++ b/core/domain/src/main/java/com/core/domain/usercase/di/UseCaseModule.kt
@@ -1,0 +1,23 @@
+package com.core.domain.usercase.di
+
+import com.core.dataapi.repository.DataStoreRepository
+import com.core.dataapi.repository.LoginRepository
+import com.core.domain.usercase.CheckTokenUseCase
+import com.core.domain.usercase.PostLoginUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UseCaseModule {
+    @Provides
+    @Singleton
+    fun providePostLoginUseCase(repository: LoginRepository) = PostLoginUseCase(repository)
+
+    @Provides
+    @Singleton
+    fun provideCheckTokenUseCase(repository: DataStoreRepository) = CheckTokenUseCase(repository)
+}

--- a/feature/home/src/main/java/com/core/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/core/home/HomeScreen.kt
@@ -53,10 +53,10 @@ fun HomeScreen() {
     Surface {
         Column(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.White)
-                    .nestedScroll(topAppbarState.nestedScrollConnection),
+            Modifier
+                .fillMaxSize()
+                .background(Color.White)
+                .nestedScroll(topAppbarState.nestedScrollConnection),
         ) {
             HomeScreenAppBar(topAppbarState = topAppbarState)
 
@@ -75,9 +75,9 @@ fun HomeScreen() {
                 item {
                     Row(
                         modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(8.dp),
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp),
                         horizontalArrangement = Arrangement.SpaceAround,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -97,23 +97,20 @@ fun HomeScreen() {
 }
 
 @Composable
-private fun CardView(
-    r: Dp,
-    count: Int,
-) {
+private fun CardView(r: Dp, count: Int) {
     Box(
         modifier =
-            Modifier
-                .fillMaxWidth()
-                .background(
-                    color = MaterialTheme.colorScheme.tertiary,
-                    shape =
-                        RoundedCornerShape(
-                            topEnd = r,
-                            topStart = r,
-                        ),
-                )
-                .padding(top = 16.dp, start = 8.dp, end = 8.dp),
+        Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.tertiary,
+                shape =
+                RoundedCornerShape(
+                    topEnd = r,
+                    topStart = r,
+                ),
+            )
+            .padding(top = 16.dp, start = 8.dp, end = 8.dp),
     ) {
         Text(text = "HomeScreen $count")
     }
@@ -151,10 +148,10 @@ private fun HomeScreenAppBar(topAppbarState: TopAppBarScrollBehavior) {
         },
         scrollBehavior = topAppbarState,
         colors =
-            TopAppBarDefaults.topAppBarColors(
-                containerColor = MaterialTheme.colorScheme.background,
-                scrolledContainerColor = MaterialTheme.colorScheme.background,
-            ),
+        TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.background,
+            scrolledContainerColor = MaterialTheme.colorScheme.background,
+        ),
     )
 }
 

--- a/feature/home/src/main/java/com/core/home/component/DropDownComponent.kt
+++ b/feature/home/src/main/java/com/core/home/component/DropDownComponent.kt
@@ -59,10 +59,10 @@ fun DropDownComponent(
 
         DropdownMenu(
             modifier =
-                Modifier
-                    .width(with(LocalDensity.current) { rowSize.width.toDp() })
-                    .height(300.dp)
-                    .background(MaterialTheme.colorScheme.background),
+            Modifier
+                .width(with(LocalDensity.current) { rowSize.width.toDp() })
+                .height(300.dp)
+                .background(MaterialTheme.colorScheme.background),
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
@@ -80,22 +80,18 @@ fun DropDownComponent(
 }
 
 @Composable
-fun DropBar(
-    expanded: Boolean,
-    selectedRegion: String?,
-    onClick: () -> Unit,
-) {
+fun DropBar(expanded: Boolean, selectedRegion: String?, onClick: () -> Unit) {
     Box(
         modifier =
-            Modifier
-                .fillMaxWidth()
-                .background(color = MaterialTheme.colorScheme.background)
-                .border(
-                    shape = RoundedCornerShape(8.dp),
-                    width = 1.dp,
-                    color = Color.Gray,
-                )
-                .clickable { onClick() },
+        Modifier
+            .fillMaxWidth()
+            .background(color = MaterialTheme.colorScheme.background)
+            .border(
+                shape = RoundedCornerShape(8.dp),
+                width = 1.dp,
+                color = Color.Gray,
+            )
+            .clickable { onClick() },
     ) {
         Row(
             modifier = Modifier.padding(8.dp),
@@ -104,17 +100,17 @@ fun DropBar(
             Text(
                 text = selectedRegion ?: "전체 지역",
                 modifier =
-                    Modifier
-                        .weight(1f)
-                        .padding(start = 8.dp),
+                Modifier
+                    .weight(1f)
+                    .padding(start = 8.dp),
                 style =
-                    MaterialTheme.typography.displayMedium.copy(Color.Gray),
+                MaterialTheme.typography.displayMedium.copy(Color.Gray),
             )
 
             Icon(
                 modifier = Modifier.size(24.dp),
                 imageVector =
-                    if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
                 contentDescription = "키 다운",
                 tint = Color.Gray,
             )

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -18,6 +18,8 @@ android {
 
 dependencies {
 
+    implementation(projects.feature.main)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/feature/login/src/main/AndroidManifest.xml
+++ b/feature/login/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         <activity
             android:name="com.core.login.LoginActivity"
             android:exported="true"
-            android:theme="@style/Theme.Youth">
+            android:theme="@style/Theme.Youth.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/feature/login/src/main/java/com/core/component/DropDownComponent.kt
+++ b/feature/login/src/main/java/com/core/component/DropDownComponent.kt
@@ -52,8 +52,8 @@ fun DropDownComponent(
 
     Column(
         modifier =
-            modifier
-                .onGloballyPositioned { rowSize = it.size.toSize() },
+        modifier
+            .onGloballyPositioned { rowSize = it.size.toSize() },
     ) {
         DropBar(expanded = expanded, selectedRegion = selectedRegion) {
             expanded = true
@@ -61,10 +61,10 @@ fun DropDownComponent(
 
         DropdownMenu(
             modifier =
-                Modifier
-                    .width(with(LocalDensity.current) { rowSize.width.toDp() })
-                    .height(300.dp)
-                    .background(MaterialTheme.colorScheme.background),
+            Modifier
+                .width(with(LocalDensity.current) { rowSize.width.toDp() })
+                .height(300.dp)
+                .background(MaterialTheme.colorScheme.background),
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
@@ -82,23 +82,19 @@ fun DropDownComponent(
 }
 
 @Composable
-fun DropBar(
-    expanded: Boolean,
-    selectedRegion: String?,
-    onClick: () -> Unit,
-) {
+fun DropBar(expanded: Boolean, selectedRegion: String?, onClick: () -> Unit) {
     Box(
         modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(5.dp)
-                .background(color = MaterialTheme.colorScheme.background)
-                .border(
-                    shape = RoundedCornerShape(8.dp),
-                    width = 1.dp,
-                    color = Color.Gray,
-                )
-                .clickable { onClick() },
+        Modifier
+            .fillMaxWidth()
+            .padding(5.dp)
+            .background(color = MaterialTheme.colorScheme.background)
+            .border(
+                shape = RoundedCornerShape(8.dp),
+                width = 1.dp,
+                color = Color.Gray,
+            )
+            .clickable { onClick() },
     ) {
         Row(
             modifier = Modifier.padding(8.dp),
@@ -107,17 +103,17 @@ fun DropBar(
             Text(
                 text = selectedRegion ?: "전체 지역",
                 modifier =
-                    Modifier
-                        .weight(1f)
-                        .padding(start = 8.dp),
+                Modifier
+                    .weight(1f)
+                    .padding(start = 8.dp),
                 style =
-                    MaterialTheme.typography.displayMedium.copy(Color.Gray),
+                MaterialTheme.typography.displayMedium.copy(Color.Gray),
             )
 
             Icon(
                 modifier = Modifier.size(24.dp),
                 imageVector =
-                    if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
                 contentDescription = "키 다운",
                 tint = Color.Gray,
             )

--- a/feature/login/src/main/java/com/core/component/RoundButton.kt
+++ b/feature/login/src/main/java/com/core/component/RoundButton.kt
@@ -15,16 +15,12 @@ import androidx.compose.ui.unit.dp
 import com.youthtalk.designsystem.YongProjectTheme
 
 @Composable
-fun RoundButton(
-    modifier: Modifier = Modifier,
-    text: String,
-    color: Color,
-) {
+fun RoundButton(modifier: Modifier = Modifier, text: String, color: Color) {
     Box(
         modifier =
-            modifier
-                .background(color, shape = RoundedCornerShape(48.dp))
-                .padding(vertical = 16.dp),
+        modifier
+            .background(color, shape = RoundedCornerShape(48.dp))
+            .padding(vertical = 16.dp),
     ) {
         Text(
             modifier = Modifier.align(Alignment.Center),

--- a/feature/login/src/main/java/com/core/login/LoginActivity.kt
+++ b/feature/login/src/main/java/com/core/login/LoginActivity.kt
@@ -1,19 +1,49 @@
 package com.core.login
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.core.splashscreen.SplashScreen
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.core.screen.LoginScreen
+import com.youthtalk.MainActivity
 import com.youthtalk.designsystem.YongProjectTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class LoginActivity : ComponentActivity() {
+    private val viewModel: LoginViewModel by viewModels()
+    private lateinit var splashScreen: SplashScreen
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        splashScreen = installSplashScreen()
+        splashScreen.setKeepOnScreenCondition { true }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.hasToken.collectLatest {
+                    splashScreen.setKeepOnScreenCondition { false }
+                    if (it) {
+                        val intent = Intent(this@LoginActivity, MainActivity::class.java)
+                        startActivity(intent)
+                        finish()
+                    }
+                }
+            }
+        }
+
         setContent {
             YongProjectTheme {
-                LoginScreen()
+                LoginScreen(viewModel)
             }
         }
     }

--- a/feature/login/src/main/java/com/core/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/core/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.core.login
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.core.domain.usercase.CheckTokenUseCase
 import com.core.domain.usercase.PostLoginUseCase
 import com.youthtalk.model.Token
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,27 +17,46 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class LoginViewModel
-    @Inject
-    constructor(
-        private val postLoginUseCase: PostLoginUseCase,
-    ) : ViewModel() {
-        private val _error = MutableSharedFlow<String>()
-        val error = _error.asSharedFlow()
+class LoginViewModel @Inject constructor(
+    private val postLoginUseCase: PostLoginUseCase,
+    private val checkTokenUseCase: CheckTokenUseCase,
+) : ViewModel() {
+    private val _error = MutableSharedFlow<String>()
+    val error = _error.asSharedFlow()
 
-        private val _token = MutableStateFlow<Token?>(null)
-        val token = _token.asStateFlow()
+    private val _hasToken = MutableSharedFlow<Boolean>()
+    val hasToken = _hasToken.asSharedFlow()
 
-        fun postLogin(userId: Long) {
-            viewModelScope.launch {
-                postLoginUseCase("kakao$userId")
-                    .catch {
-                        _error.emit(it.message ?: "")
-                    }
-                    .collectLatest {
-                        Log.d("YOON-CHAN", "LoginViewModel ${it.accessToken} ${it.refreshToken}")
-                        _token.value = it
-                    }
-            }
+    private val _token = MutableStateFlow<Token?>(null)
+    val token = _token.asStateFlow()
+
+    init {
+        checkToken()
+    }
+
+    private fun checkToken() {
+        viewModelScope.launch {
+            checkTokenUseCase()
+                .catch {
+                    Log.d("YOON-CHAN", "checkTokenUseCase Error $it")
+                }
+                .collectLatest {
+                    Log.d("YOON-CHAN", "checkTokenUseCase Success $it")
+                    _hasToken.emit(it)
+                }
         }
     }
+
+    fun postLogin(userId: Long) {
+        viewModelScope.launch {
+            postLoginUseCase("kakao$userId")
+                .catch {
+                    _error.emit(it.message ?: "")
+                }
+                .collectLatest {
+                    Log.d("YOON-CHAN", "LoginViewModel ${it.accessToken} ${it.refreshToken}")
+                    _token.value = it
+                }
+        }
+    }
+}

--- a/feature/login/src/main/java/com/core/screen/AgreeScreen.kt
+++ b/feature/login/src/main/java/com/core/screen/AgreeScreen.kt
@@ -27,19 +27,19 @@ import com.youthtalk.designsystem.YongProjectTheme
 fun AgreeScreen() {
     Column(
         modifier =
-            Modifier
-                .fillMaxSize()
-                .background(Color.White),
+        Modifier
+            .fillMaxSize()
+            .background(Color.White),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             modifier = Modifier.padding(top = 14.dp),
             text = "약관동의",
             style =
-                MaterialTheme.typography.displayLarge.copy(
-                    fontWeight = FontWeight.W700,
-                    color = Color.Black,
-                ),
+            MaterialTheme.typography.displayLarge.copy(
+                fontWeight = FontWeight.W700,
+                color = Color.Black,
+            ),
         )
 
         // 약관 동의 글
@@ -57,9 +57,9 @@ fun AgreeScreen() {
 private fun AgreeScreenButton() {
     Row(
         modifier =
-            Modifier
-                .padding(top = 14.dp, bottom = 21.dp)
-                .padding(horizontal = 25.dp),
+        Modifier
+            .padding(top = 14.dp, bottom = 21.dp)
+            .padding(horizontal = 25.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         RoundButton(
@@ -83,17 +83,17 @@ private fun DetailAgreeTextQuestion() {
         Text(
             text = stringResource(id = R.string.agree_subtitle),
             style =
-                MaterialTheme.typography.bodyMedium
-                    .copy(fontWeight = FontWeight.W700),
+            MaterialTheme.typography.bodyMedium
+                .copy(fontWeight = FontWeight.W700),
         )
         Text(
             text = stringResource(id = R.string.agree_subtitle2),
             style =
-                MaterialTheme.typography.bodySmall
-                    .copy(
-                        fontWeight = FontWeight.W400,
-                        color = Color(0xFF929292),
-                    ),
+            MaterialTheme.typography.bodySmall
+                .copy(
+                    fontWeight = FontWeight.W400,
+                    color = Color(0xFF929292),
+                ),
         )
     }
 }
@@ -102,11 +102,11 @@ private fun DetailAgreeTextQuestion() {
 private fun ColumnScope.DetailAgreeText() {
     Box(
         modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 30.dp, vertical = 21.dp)
-                .background(color = Color(0xFFf3f3f3))
-                .weight(1f),
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 30.dp, vertical = 21.dp)
+            .background(color = Color(0xFFf3f3f3))
+            .weight(1f),
     ) {
         Text(
             modifier = Modifier.align(Alignment.Center),

--- a/feature/login/src/main/java/com/core/screen/InformationScreen.kt
+++ b/feature/login/src/main/java/com/core/screen/InformationScreen.kt
@@ -27,19 +27,19 @@ import com.youthtalk.designsystem.YongProjectTheme
 fun InformationScreen() {
     Column(
         modifier =
-            Modifier
-                .fillMaxSize()
-                .background(Color.White),
+        Modifier
+            .fillMaxSize()
+            .background(Color.White),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         InformationTitleScreen()
 
         Column(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(top = 58.dp)
-                    .weight(1f),
+            Modifier
+                .fillMaxSize()
+                .padding(top = 58.dp)
+                .weight(1f),
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
@@ -49,10 +49,10 @@ fun InformationScreen() {
 
         RoundButton(
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 76.dp)
-                    .padding(horizontal = 24.dp),
+            Modifier
+                .fillMaxWidth()
+                .padding(bottom = 76.dp)
+                .padding(horizontal = 24.dp),
             text = "시작하기",
             color = Color(0xFFE3E5E5),
         )
@@ -82,10 +82,10 @@ private fun NickNameScreen() {
     )
     BasicTextField(
         modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 23.dp)
-                .border(width = 1.dp, shape = RoundedCornerShape(8.dp), color = Color(0xFFCDCFD0)),
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 23.dp)
+            .border(width = 1.dp, shape = RoundedCornerShape(8.dp), color = Color(0xFFCDCFD0)),
         value = "123",
         textStyle = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.W700),
         onValueChange = {},
@@ -94,9 +94,9 @@ private fun NickNameScreen() {
 
         Row(
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(start = 25.dp, top = 10.dp, bottom = 10.dp),
+            Modifier
+                .fillMaxWidth()
+                .padding(start = 25.dp, top = 10.dp, bottom = 10.dp),
         ) {
             innerTextField()
         }
@@ -112,12 +112,12 @@ private fun NickNameScreen() {
 private fun InformationTitleScreen() {
     Text(
         modifier =
-            Modifier
-                .padding(top = 35.dp),
+        Modifier
+            .padding(top = 35.dp),
         text = "청년톡톡과 함께할 정보를 입력해주세요",
         style =
-            MaterialTheme.typography.displayLarge
-                .copy(fontWeight = FontWeight.W700),
+        MaterialTheme.typography.displayLarge
+            .copy(fontWeight = FontWeight.W700),
     )
 }
 

--- a/feature/login/src/main/java/com/core/screen/LoginScreen.kt
+++ b/feature/login/src/main/java/com/core/screen/LoginScreen.kt
@@ -46,7 +46,7 @@ import com.youthtalk.model.Token
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
-fun LoginScreen(viewModel: LoginViewModel = hiltViewModel()) {
+fun LoginScreen(viewModel: LoginViewModel) {
     val context = LocalContext.current
 
     val token by viewModel.token.collectAsState()
@@ -71,10 +71,7 @@ fun LoginScreen(viewModel: LoginViewModel = hiltViewModel()) {
     )
 }
 
-private fun kakaoLogin(
-    context: Context,
-    onSuccess: (Long) -> Unit,
-) {
+private fun kakaoLogin(context: Context, onSuccess: (Long) -> Unit) {
 // 카카오계정으로 로그인 공통 callback 구성
 // 카카오톡으로 로그인 할 수 없어 카카오계정으로 로그인할 경우 사용됨
     val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
@@ -133,20 +130,17 @@ private fun kakaoLogin(
 }
 
 @Composable
-fun LoginScreen(
-    onClick: () -> Unit,
-    token: Token?,
-) {
+fun LoginScreen(onClick: () -> Unit, token: Token?) {
     Surface(
         modifier =
-            Modifier
-                .fillMaxSize(),
+        Modifier
+            .fillMaxSize(),
     ) {
         Box(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(color = MaterialTheme.colorScheme.background),
+            Modifier
+                .fillMaxSize()
+                .background(color = MaterialTheme.colorScheme.background),
         ) {
             LogoText(token)
             KaKaoImage(onClick = onClick)
@@ -158,8 +152,8 @@ fun LoginScreen(
 private fun LogoText(token: Token?) {
     Column(
         modifier =
-            Modifier
-                .fillMaxSize(),
+        Modifier
+            .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -176,8 +170,8 @@ private fun LogoText(token: Token?) {
         Text(
             text = stringResource(id = R.string.login_screen_description),
             style =
-                MaterialTheme.typography.bodySmall
-                    .copy(color = Color.Black),
+            MaterialTheme.typography.bodySmall
+                .copy(color = Color.Black),
         )
 
         Text(text = "${token?.accessToken} ${token?.refreshToken}")
@@ -188,15 +182,15 @@ private fun LogoText(token: Token?) {
 fun BoxScope.KaKaoImage(onClick: () -> Unit) {
     Image(
         modifier =
-            Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 16.dp)
-                .clickable { onClick() },
+        Modifier
+            .align(Alignment.BottomCenter)
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 16.dp)
+            .clickable { onClick() },
         painter =
-            painterResource(
-                id = R.drawable.kakao_login_large_wide,
-            ),
+        painterResource(
+            id = R.drawable.kakao_login_large_wide,
+        ),
         contentScale = ContentScale.FillWidth,
         contentDescription = stringResource(id = R.string.kakao_description),
     )
@@ -205,7 +199,8 @@ fun BoxScope.KaKaoImage(onClick: () -> Unit) {
 @Preview
 @Composable
 private fun LoginScreenPreview() {
+    val viewModel: LoginViewModel = hiltViewModel()
     YongProjectTheme {
-        LoginScreen()
+        LoginScreen(viewModel)
     }
 }

--- a/feature/login/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/feature/login/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:pathData="M31,63.928c0,0 6.4,-11 12.1,-13.1c7.2,-2.6 26,-1.4 26,-1.4l38.1,38.1L107,108.928l-32,-1L31,63.928z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="85.84757"
+                android:endY="92.4963"
+                android:startX="42.9492"
+                android:startY="49.59793"
+                android:type="linear">
+                <item
+                    android:color="#44000000"
+                    android:offset="0.0" />
+                <item
+                    android:color="#00000000"
+                    android:offset="1.0" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillType="nonZero"
+        android:pathData="M65.3,45.828l3.8,-6.6c0.2,-0.4 0.1,-0.9 -0.3,-1.1c-0.4,-0.2 -0.9,-0.1 -1.1,0.3l-3.9,6.7c-6.3,-2.8 -13.4,-2.8 -19.7,0l-3.9,-6.7c-0.2,-0.4 -0.7,-0.5 -1.1,-0.3C38.8,38.328 38.7,38.828 38.9,39.228l3.8,6.6C36.2,49.428 31.7,56.028 31,63.928h46C76.3,56.028 71.8,49.428 65.3,45.828zM43.4,57.328c-0.8,0 -1.5,-0.5 -1.8,-1.2c-0.3,-0.7 -0.1,-1.5 0.4,-2.1c0.5,-0.5 1.4,-0.7 2.1,-0.4c0.7,0.3 1.2,1 1.2,1.8C45.3,56.528 44.5,57.328 43.4,57.328L43.4,57.328zM64.6,57.328c-0.8,0 -1.5,-0.5 -1.8,-1.2s-0.1,-1.5 0.4,-2.1c0.5,-0.5 1.4,-0.7 2.1,-0.4c0.7,0.3 1.2,1 1.2,1.8C66.5,56.528 65.6,57.328 64.6,57.328L64.6,57.328z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+</vector>

--- a/feature/login/src/main/res/values/themes.xml
+++ b/feature/login/src/main/res/values/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Youth.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">#FFD0BCFF</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/Theme.SplashScreen</item>
+    </style>
+
+</resources>

--- a/feature/main/src/main/java/com/youthtalk/MainScreen.kt
+++ b/feature/main/src/main/java/com/youthtalk/MainScreen.kt
@@ -77,11 +77,7 @@ fun NavHostScreen(navController: NavHostController) {
 }
 
 @Composable
-fun BottomBar(
-    navHostController: NavHostController,
-    currentRoute: String?,
-    modifier: Modifier = Modifier,
-) {
+fun BottomBar(navHostController: NavHostController, currentRoute: String?, modifier: Modifier = Modifier) {
     val bottomNavigation =
         listOf(
             MainNav.Community,
@@ -91,9 +87,9 @@ fun BottomBar(
 
     Row(
         modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp),
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
@@ -109,24 +105,20 @@ fun BottomBar(
 }
 
 @Composable
-fun RowScope.BottomIcon(
-    navHostController: NavHostController,
-    mainNav: MainNav,
-    color: Color,
-) {
+fun RowScope.BottomIcon(navHostController: NavHostController, mainNav: MainNav, color: Color) {
     Box(
         modifier =
-            Modifier
-                .fillMaxSize()
-                .weight(1f)
-                .align(Alignment.CenterVertically)
-                .clickable {
-                    navHostController.navigate(mainNav.route) {
-                        popUpTo(MainNav.Home.route)
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                },
+        Modifier
+            .fillMaxSize()
+            .weight(1f)
+            .align(Alignment.CenterVertically)
+            .clickable {
+                navHostController.navigate(mainNav.route) {
+                    popUpTo(MainNav.Home.route)
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            },
     ) {
         Column(
             modifier = Modifier.align(Alignment.Center),
@@ -135,14 +127,14 @@ fun RowScope.BottomIcon(
         ) {
             Box(
                 modifier =
-                    Modifier
-                        .size(24.dp),
+                Modifier
+                    .size(24.dp),
             ) {
                 Icon(
                     modifier =
-                        Modifier
-                            .align(Alignment.Center)
-                            .size(24.dp),
+                    Modifier
+                        .align(Alignment.Center)
+                        .size(24.dp),
                     painter = painterResource(id = mainNav.icon),
                     contentDescription = mainNav.title,
                     tint = color,
@@ -151,8 +143,8 @@ fun RowScope.BottomIcon(
             Text(
                 text = mainNav.title,
                 style =
-                    MaterialTheme.typography.bodySmall
-                        .copy(color = color, fontWeight = FontWeight.Bold),
+                MaterialTheme.typography.bodySmall
+                    .copy(color = color, fontWeight = FontWeight.Bold),
             )
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,8 @@
 [versions]
 agp = "8.5.0"
+coreSplashscreen = "1.0.1"
+datastorePreferences = "1.1.1"
+datastorePreferencesCore = "1.1.1"
 detektRulesLibraries = "1.23.6"
 firebaseBom = "33.1.1"
 gson = "2.11.0"
@@ -51,6 +54,7 @@ kakaoUser = "2.20.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-compose-navigation-test = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationCompose" }
 androidx-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "runtime" }
@@ -122,6 +126,9 @@ okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp
 okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 
+# dataStroe - preference
+androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastorePreferencesCore" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# 이슈 번호

closed #39 

# :fire: 기능 구현 리스트

- [X] Splash Screen을 이용하여 로그인 or 메인 화면 보이도록 구현

---

# :pencil2: 변경된 부분 상세 내용 적기

Preferences dataStore를 구현

dataStore를 이용하여 Token값이 비어있는지 여부를 판단하여 Splash Screen 이후 로그인 화면 또는 메인화면을 보이도록 기능 구현

## 1. 추가한 데이터 모델

+ DataStore

## 2. 레파지토리 또는 유즈케이스문

+ DataStoreRepository
+ CheckTokenUseCase

## 3. UI 및 ViewModel 변경점
 + splash screen 의존성 주입
+ LoginActivity에 splash screen 적용
    + 앱 시작시 토큰 여부를 확인하는 함수 사용하여 토큰 여부에 따라 보이는 화면을 구성


# :globe_with_meridians: 질문 및 정리글 링크

스플래시 화면
https://developer.android.com/develop/ui/views/launch/splash-screen?hl=ko

데이터 스토어
https://developer.android.com/topic/libraries/architecture/datastore?hl=ko
https://velog.io/@i_meant_to_be/Proto-With-Hilt-Jetpack-Compose
