### PR TITLE
로그인 토큰 로직 변경

### DIFF
--- a/core/data/src/main/java/com/youthtalk/di/AuthAuthenticator.kt
+++ b/core/data/src/main/java/com/youthtalk/di/AuthAuthenticator.kt
@@ -16,20 +16,31 @@ class AuthAuthenticator @Inject constructor(
 
     companion object {
         const val AUTHORIZATION = "Authorization"
+        const val AUTHORIZATION_REFRESH = "Authorization-refresh"
     }
 
     override fun authenticate(route: Route?, response: Response): Request? {
         val refreshToken = runBlocking {
             dataStoreDataSource.getRefreshToken().first()
         }
-        Log.d("YOON-CHAN", "AuthAuthenticator refreshToken $refreshToken")
-        if (refreshToken == null) {
+        val requestAuthorizationHeader = response.request.headers[AUTHORIZATION]
+        val requestAuthorizationRefreshHeader = response.request.headers[AUTHORIZATION_REFRESH]
+        Log.d(
+            "YOON-CHAN",
+            "AuthAuthenticator refreshToken $refreshToken," +
+                "\n requestAuthorizationHeader $requestAuthorizationHeader," +
+                "\n requestAuthorizationRefreshHeader $requestAuthorizationRefreshHeader," +
+                "\n message ${response.body?.string()}",
+        )
+        if (refreshToken == null || requestAuthorizationRefreshHeader == "Bearer $refreshToken") {
+            Log.d("YOON-CHAN", "no refresh Token")
             response.close()
             return null
         }
 
+        Log.d("YOON-CHAN", "Change Header")
         return response.request.newBuilder()
-            .addHeader(AUTHORIZATION, "Bearer $refreshToken")
+            .addHeader(AUTHORIZATION_REFRESH, "Bearer $refreshToken")
             .build()
     }
 }

--- a/core/data/src/main/java/com/youthtalk/di/AuthInterceptor.kt
+++ b/core/data/src/main/java/com/youthtalk/di/AuthInterceptor.kt
@@ -36,33 +36,60 @@ class AuthInterceptor @Inject constructor(
             .addHeader(AUTHORIZATION, "Bearer $token")
             .build()
 
-        val response = chain.proceed(request)
+        try {
+            val response = chain.proceed(request)
 
-        Log.d("YOON-CHAN", "AuthInterceptor response code ${response.code} $token")
-        if (response.code == HTTP_OK) {
-            val newAccessToken: String = response.header(AUTHORIZATION, null) ?: return response
-            val newRefreshToken: String = response.header(AUTHORIZATION_REFRESH, null) ?: return response
+            Log.d(
+                "YOON-CHAN",
+                "AuthInterceptor response code ${response.code}," +
+                    "\n request Header ${response.request.headers[AUTHORIZATION]}" +
+                    " \n request refresh Header ${response.request.headers[AUTHORIZATION_REFRESH]}",
+            )
+            if (response.code == HTTP_OK) {
+                val newAccessToken: String = response.header(AUTHORIZATION, null) ?: return response
+                val newRefreshToken: String = response.header(AUTHORIZATION_REFRESH, null) ?: return response
 
-            Log.d("YOON-CHAN", "new Access Token = $newAccessToken, new Refresh Token $newRefreshToken")
-            CoroutineScope(Dispatchers.IO).launch {
-                val currentAccessToken = dataStoreDataSource.getAccessToken().first()
-                if (currentAccessToken != newAccessToken) {
-                    dataStoreDataSource.saveAccessToken(newAccessToken)
-                    dataStoreDataSource.saveRefreshToken(newRefreshToken)
-                    Log.d("YOON-CHAN", "save new Access Token")
+                Log.d("YOON-CHAN", "new Access Token = $newAccessToken, new Refresh Token $newRefreshToken")
+                CoroutineScope(Dispatchers.IO).launch {
+                    val currentAccessToken = dataStoreDataSource.getAccessToken().first()
+                    if (currentAccessToken != newAccessToken) {
+                        dataStoreDataSource.saveAccessToken(newAccessToken)
+                        dataStoreDataSource.saveRefreshToken(newRefreshToken)
+                        Log.d("YOON-CHAN", "save new Access Token")
+                    }
                 }
+                val newRequest = chain.request().newBuilder()
+                    .addHeader("Content-Type", "application/json")
+                    .addHeader(AUTHORIZATION, "Bearer $newAccessToken")
+                    .build()
+                return chain.proceed(newRequest)
             }
-        } else {
-            // Log.d("YOON-CHAN", "not 200")
-//            if(response.code == 403) {
-//                return response.
-//            }
-        }
 
-        return response
+            return response
+        } catch (e: IllegalStateException) {
+            Log.d("YOON-CHAN", "AuthInterceptor ${e.message}")
+            return refreshTokenExpiredResponse(request)
+        }
     }
 
     private fun errorResponse(request: Request): Response {
+        val responseBody = CommonResponse<Unit>(
+            code = "M01",
+            status = HTTP_UNAUTHORIZED,
+            message = "",
+            data = null,
+        )
+
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_2)
+            .code(HTTP_UNAUTHORIZED)
+            .message("")
+            .body(toResponseBody(responseBody))
+            .build()
+    }
+
+    private fun refreshTokenExpiredResponse(request: Request): Response {
         val responseBody = CommonResponse<Unit>(
             code = "M01",
             status = HTTP_UNAUTHORIZED,

--- a/core/data/src/main/java/com/youthtalk/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/youthtalk/repository/UserRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.youthtalk.repository
 
+import android.util.Log
 import com.core.dataapi.repository.UserRepository
 import com.core.datastore.datasource.DataStoreDataSource
 import com.youthtalk.data.UserService
@@ -17,11 +18,13 @@ class UserRepositoryImpl @Inject constructor(
     override fun getUser(): Flow<User> = flow {
         runCatching { userService.getUser() }
             .onSuccess { response ->
+                Log.d("YOON-CHAN", "getUser Success ${response.data}")
                 response.data?.let { userResponse ->
                     emit(userResponse.toData())
                 }
             }
             .onFailure {
+                Log.d("YOON-CHAN", "getUser Error ${it.message}")
                 throw it
             }
     }

--- a/feature/home/src/main/java/com/core/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/core/home/HomeScreen.kt
@@ -53,9 +53,7 @@ fun HomeScreen() {
                 item { SearchScreen() }
                 item { CategoryScreen(categoryList) }
                 item { PopularTitle() }
-                item(
-                    key = top5Policies,
-                ) { PopularPolicyScreen(top5Policies) }
+                item { PopularPolicyScreen(top5Policies) }
                 item { UpdateTitle() }
                 items(
                     items = policies,


### PR DESCRIPTION
# :fire: 기능 구현 리스트

- [X] 서버 access, refresh token 만료 에러 410로 변경
- [X] accessToken 만료 시 refreshToken 헤더에 넣어 호출 후 새로운 accessToken, refreshToken 저장하기
- [X] refreshToken 만료 시 401 에러 출력하도록 변경(401 에러 발생 시 로그인 화면으로 이동 하도록 구현하기
---

# :pencil2: 변경된 부분 상세 내용 적기
- 로그인 로직 변경하기

## 1. 추가한 데이터 모델

## 2. 레파지토리 또는 유즈케이스문

## 3. UI 및 ViewModel 변경점

## 4. 기능 구현 리스트 정리 내용

---

# :globe_with_meridians: 질문 및 정리글 링크
