### PR TITLE
hostDep이 null일 경우 앱이 팅기는 문제

### DIFF
--- a/core/data/src/main/java/com/youthtalk/dto/policy/PolicyResponse.kt
+++ b/core/data/src/main/java/com/youthtalk/dto/policy/PolicyResponse.kt
@@ -9,7 +9,7 @@ data class PolicyResponse(
     val category: Category,
     val title: String,
     val deadlineStatus: String,
-    val hostDep: String,
+    val hostDep: String = "",
     val scrapCount: Int,
     val departmentImgUrl: String?,
     val region: String,


### PR DESCRIPTION
# :fire: 기능 구현 리스트

- [x] hostDep의 기본값을 설정

---

다음 배포에 리팩터링하면서 더 살펴보자

This closes #236 
