### PR TITLE
 내가 달은 댓글 조회 기능 추가

### DIFF
--- a/core/data/src/main/java/com/youthtalk/data/CommentService.kt
+++ b/core/data/src/main/java/com/youthtalk/data/CommentService.kt
@@ -18,9 +18,6 @@ interface CommentService {
     @DELETE("/api/v1/comments/{commentId}")
     suspend fun postDeleteComment(@Path("commentId") commentId: Long): CommonResponse<PostAddCommentResponse>
 
-    @GET("/api/v1/members/me/comments")
-    suspend fun getMyComments()
-
     @POST("/api/v1/posts/comments")
     suspend fun postPostAddComment(@Body requestBody: RequestBody): CommonResponse<PostAddCommentResponse>
 

--- a/feature/mypage/src/main/java/com/core/mypage/screen/CommentScreen.kt
+++ b/feature/mypage/src/main/java/com/core/mypage/screen/CommentScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -163,10 +164,9 @@ fun CommentScreen(
                 }
 
                 items(
-                    count = state.commentInfo.commentCount,
-                    key = { state.commentInfo.comments[it].commentId }
-                ) {
-                    val comment = state.commentInfo.comments[it]
+                    items = state.commentInfo.comments,
+                    key = { it.commentId }
+                ) { comment ->
                     CommentCard(
                         isMyType = state.commentType == CommentType.MY,
                         isMine = state.commentType == CommentType.MY || (comment.writerId == state.user.memberId),

--- a/feature/mypage/src/main/java/com/core/mypage/screen/CommentScreen.kt
+++ b/feature/mypage/src/main/java/com/core/mypage/screen/CommentScreen.kt
@@ -51,12 +51,12 @@ import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun CommentScreenRoot(
-    modifier: Modifier = Modifier,
     viewModel: CommentViewModel = hiltViewModel(),
     onBack: () -> Unit,
     showSnackBar: (String) -> Unit,
     onClickPostDetail: (Long) -> Unit,
-    onClickPolicyDetail: (Long) -> Unit
+    onClickPolicyDetail: (Long) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     var comments by rememberSaveable {
@@ -87,7 +87,6 @@ fun CommentScreenRoot(
             }
         }
     }
-
     if (!state.isLoading) {
         Crossfade(
             modifier = modifier,
@@ -123,11 +122,11 @@ fun CommentScreenRoot(
 
 @Composable
 fun CommentScreen(
-    modifier: Modifier = Modifier,
     state: CommentUiState,
     lazyListState: LazyListState,
     actionEvent: (CommentUiEvent) -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier

--- a/feature/mypage/src/main/java/com/core/mypage/screen/CommentScreen.kt
+++ b/feature/mypage/src/main/java/com/core/mypage/screen/CommentScreen.kt
@@ -121,7 +121,7 @@ fun CommentScreenRoot(
 }
 
 @Composable
-fun CommentScreen(
+internal fun CommentScreen(
     state: CommentUiState,
     lazyListState: LazyListState,
     actionEvent: (CommentUiEvent) -> Unit,


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명

내가 달은 댓글 조회가 안되는줄 알았지만
사실은 조회가 잘 되고 있었다.

CommentService에 내 댓글을 조회하는 함수가 있었지만
함수를 사용하는쪽은 없어서 확인해봤더니 UserService에 내 댓글 조회 함수가 있고
해당 함수를 사용중이었다.

리팩터링만 진행했다.
- LazyItem의 items에 count를 받던것에서 items 자체를 받도록 설정
- CommentScreen의 modifier를 선택적 파라미터의 첫번째 파라미터로 변경
- CommentScreen의 접근 제어자를 internal로 변경

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)

This closes #262 
