### PR TITLE
 곧 마감되는 정책의 정책간 패딩이 적용되지 않던 이슈 수정

### DIFF
--- a/feature/policy/src/main/java/com/feature/policy/screen/DeadlinePolicyScreen.kt
+++ b/feature/policy/src/main/java/com/feature/policy/screen/DeadlinePolicyScreen.kt
@@ -42,10 +42,10 @@ import com.youthtalk.designsystem.gray40
 
 @Composable
 fun DeadlinePolicyScreen(
-    modifier: Modifier = Modifier,
     viewModel: DeadlineViewmodel = hiltViewModel(),
     onBack: () -> Unit,
-    onClickPolicyDetail: (Long) -> Unit
+    onClickPolicyDetail: (Long) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val policies = state.policies.collectAsLazyPagingItems()

--- a/feature/policy/src/main/java/com/feature/policy/screen/DeadlinePolicyScreen.kt
+++ b/feature/policy/src/main/java/com/feature/policy/screen/DeadlinePolicyScreen.kt
@@ -80,7 +80,8 @@ fun DeadlinePolicyScreen(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp)
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 item {
                     Row(


### PR DESCRIPTION
최근 올라온 정책과 동일하게 12.dp

🔗 관련 이슈

📙 작업 설명
곧 마감되는 정책의 정책간 패딩이 적용되어있지 않았다.

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)
![image](https://github.com/user-attachments/assets/743144f0-1a4d-4764-9c75-1e7711f16e3d)

💬 추가 설명 or 리뷰 포인트 (선택)

This closes #268 