### PR TITLE
 첫 진입시 필터 전체가 선택되지 않게 변경

### DIFF
--- a/core/designsystem/src/main/java/com/youthtalk/component/sheet/FilterBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/youthtalk/component/sheet/FilterBottomSheet.kt
@@ -407,7 +407,7 @@ fun PolicyType(modifier: Modifier = Modifier, category: List<Category>?, onClick
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         RoundChip(
-            text = "전체지역",
+            text = "전체 선택",
             isSelected = category == null,
             onClick = { onClick(null) }
         )

--- a/core/designsystem/src/main/java/com/youthtalk/model/FilterType.kt
+++ b/core/designsystem/src/main/java/com/youthtalk/model/FilterType.kt
@@ -1,7 +1,6 @@
 package com.youthtalk.model
 
 import com.youthtalk.model.search.SearchFilter
-import com.youthtalk.util.SpecializedUtils
 
 enum class FilterType(val title: String) {
     POLICY_TYPE("정책분야"),
@@ -18,9 +17,13 @@ fun FilterType.getCountFrom(filter: SearchFilter): Int = when (this) {
     FilterType.RECRUIT -> filter.employment?.size ?: 0
     FilterType.EDUCATION -> filter.education?.size ?: 0
     FilterType.SPECIALIZED -> {
-        val specialCount = SpecializedUtils.getFilterList(filter.specialization)?.size ?: 0
-        val marriedCount = if (filter.marriage != null) 1 else 0
-        specialCount + marriedCount
+        if (filter.specialization.isNullOrEmpty()) {
+            0
+        } else {
+            val specialCount = filter.specialization?.size ?: 0
+            val marriedCount = if (filter.marriage != null) 1 else 0
+            specialCount + marriedCount
+        }
     }
 
     FilterType.AGE_EARN -> {

--- a/core/designsystem/src/main/java/com/youthtalk/util/SpecializedUtils.kt
+++ b/core/designsystem/src/main/java/com/youthtalk/util/SpecializedUtils.kt
@@ -24,20 +24,22 @@ object SpecializedUtils {
     fun getAllList(types: List<SpecializedType>): List<SpecializedType> = listOf(SpecializedType.UNRESTRICTED) + types
 
     fun isChecked(value: List<SpecializedType>, item: SpecializedType, specials: List<SpecializedType>?): Boolean {
-        return when (item) {
-            SpecializedType.UNRESTRICTED ->
-                value.all { filter -> specials?.contains(filter) == false } ||
-                    specials == null
-
-            else -> !value.all { filter -> specials?.contains(filter) == true } &&
-                specials?.contains(item) == true
-        }
+        if (specials.isNullOrEmpty()) return false
+        if (specials.containsAll(value)) return item == SpecializedType.UNRESTRICTED
+        return specials.contains(item)
     }
 
     fun changeSpecialized(value: List<SpecializedType>, item: SpecializedType, specials: List<SpecializedType>?): List<SpecializedType>? {
         val newFilter = when (item) {
-            SpecializedType.UNRESTRICTED ->
-                specials?.filter { filter -> !value.contains(filter) }
+            SpecializedType.UNRESTRICTED -> {
+                if (specials.isNullOrEmpty()) {
+                    return value
+                } else if (specials.containsAll(value)) {
+                    specials - value.toSet()
+                } else {
+                    specials + value
+                }
+            }
 
             else -> {
                 val currentFilter = specials ?: listOf()
@@ -46,22 +48,11 @@ object SpecializedUtils {
                 } else {
                     currentFilter + item
                 }
-                if (value.all { changes.contains((it)) }) {
-                    currentFilter.filter { !value.contains(it) }
-                } else {
-                    changes
-                }
+                changes
             }
         }
 
-        return if (
-            newFilter.isNullOrEmpty() ||
-            newFilter.size == SpecializedType.entries.size - 1
-        ) {
-            null
-        } else {
-            newFilter
-        }
+        return newFilter
     }
 
     fun getFilterList(values: List<SpecializedType>?): List<SpecializedType>? {

--- a/core/model/src/main/java/com/youthtalk/model/search/SearchFilter.kt
+++ b/core/model/src/main/java/com/youthtalk/model/search/SearchFilter.kt
@@ -13,13 +13,13 @@ import okhttp3.RequestBody.Companion.toRequestBody
 @Serializable
 data class SearchFilter(
     val keyword: String? = null,
-    val category: List<Category>? = null,
+    val category: List<Category>? = emptyList(),
     val marriage: MarriageType? = null,
     val age: String? = null,
-    val education: List<EducationType>? = null,
-    val employment: List<EmploymentType>? = null,
-    val specialization: List<SpecializedType>? = null,
-    val region: List<String>? = null,
+    val education: List<EducationType>? = emptyList(),
+    val employment: List<EmploymentType>? = emptyList(),
+    val specialization: List<SpecializedType>? = emptyList(),
+    val region: List<String>? = emptyList(),
     val minEarn: Int? = null,
     val maxEarn: Int? = null,
     val applyDue: String? = null


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
정책에서 전체지역으로 되어있는것 전체 선택으로 변경
정책 필터 바텀시트에 첫 진입시 필터 전체가 선택되지 않게 변경

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)


💬 추가 설명 or 리뷰 포인트 (선택)


This closes #267 
