### PR TITLE
내 계정 화면에서 뒤로가기 버튼을 눌렀을때 편집하기 버튼이 클릭이 안되던점 수정

### DIFF
--- a/feature/mypage/src/main/java/com/core/mypage/screen/SettingAccount.kt
+++ b/feature/mypage/src/main/java/com/core/mypage/screen/SettingAccount.kt
@@ -145,10 +145,11 @@ fun SettingAccount(modifier: Modifier = Modifier, user: User, uploadLoading: Boo
             subTitle = "화면을 나가면 변경사항이 저장되지 않습니다.\n나가시겠습니까?",
             confirmText = "편집하기",
             cancelText = "나가기",
-            onDismissRequest = { logoutDialog = false },
+            onDismissRequest = { onBackDialog = false },
             onClickCancel = {
                 actionEvent(SettingUiEvent.ChangeSettingType(SettingType.MAIN))
-            }
+            },
+            onClickConfirm = { onBackDialog = false }
         )
     }
 


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
편집하기 버튼에 클릭 리스너가 달려있지 않던것 수정
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)

This closes #292 