### PR TITLE
신고한 게시글을 클릭했을때 무한 로딩이 걸리던 이슈 수정

### DIFF
--- a/feature/community/src/main/java/com/core/community/model/detail/CommunityDetailUiEffect.kt
+++ b/feature/community/src/main/java/com/core/community/model/detail/CommunityDetailUiEffect.kt
@@ -9,4 +9,5 @@ sealed interface CommunityDetailUiEffect : UiEffect {
     data object ShowSnackBarReportPost : CommunityDetailUiEffect
     data object ShowSnackBarReportComment : CommunityDetailUiEffect
     data class ShowSnackBarReportFail(val message: String?) : CommunityDetailUiEffect
+    data class InitError(val message: String) : CommunityDetailUiEffect
 }

--- a/feature/community/src/main/java/com/core/community/screen/detail/CommunityDetailScreen.kt
+++ b/feature/community/src/main/java/com/core/community/screen/detail/CommunityDetailScreen.kt
@@ -142,6 +142,10 @@ fun CommunityDetailScreen(
                 is CommunityDetailUiEffect.ShowSnackBarReportFail -> {
                     showSnackBar(it.message.toString())
                 }
+                is CommunityDetailUiEffect.InitError -> {
+                    showSnackBar(it.message)
+                    onBack()
+                }
             }
         }
     }

--- a/feature/community/src/main/java/com/core/community/viewmodel/CommunityDetailViewModel.kt
+++ b/feature/community/src/main/java/com/core/community/viewmodel/CommunityDetailViewModel.kt
@@ -232,6 +232,7 @@ class CommunityDetailViewModel @Inject constructor(
             }
                 .catch {
                     Timber.e("CommunityDetailViewModel initData error $it")
+                    setEffect { CommunityDetailUiEffect.InitError("신고한 게시글은 조회할 수 없습니다.") }
                 }
                 .collectLatest { uiState ->
                     setState { uiState }


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
신고한 게시글을 클릭했을 때 무한 로딩이 걸리던 것을
게시글에서 바로 나오도록 설정
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)

This closes #297 
