### PR TITLE
LoginRepository의 메서드 반환값을 Flow에서 one-show 방식으로 변경

### DIFF
--- a/core/data/src/main/java/com/youthtalk/repository/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/youthtalk/repository/LoginRepositoryImpl.kt
@@ -4,40 +4,30 @@ import com.core.dataapi.repository.LoginRepository
 import com.core.datastore.datasource.DataStoreDataSource
 import com.core.exception.NoDataException
 import com.youthtalk.data.LoginService
-import com.youthtalk.dto.MemberId
 import com.youthtalk.dto.login.LoginRequest
 import com.youthtalk.dto.login.SignRequest
 import com.youthtalk.model.typeenum.toRegion
-import com.youthtalk.utils.ErrorUtils.throwableError
+import com.youthtalk.utils.ErrorUtils.createResult
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import timber.log.Timber
 
 class LoginRepositoryImpl @Inject constructor(
     private val loginService: LoginService,
     private val dataStoreDataSource: DataStoreDataSource
 ) : LoginRepository {
-    override fun postLogin(socialId: String): Flow<Long> = flow {
-        Timber.e("LoginRepositoryImpl postLogin start")
-        runCatching { loginService.postLogin(LoginRequest(socialType = "kakao", socialId = socialId).toRequestBody()) }
-            .onSuccess { token ->
-                Timber.e("LoginRepositoryImpl postLogin Success $token")
-                token.data?.let { data ->
-                    emit(data.memberId)
-                } ?: throw NoDataException()
-            }
-            .onFailure { error ->
-                Timber.e("LoginRepositoryImpl postLogin  error : $error")
-                throwableError<MemberId>(error)
-            }
+    override suspend fun postLogin(socialId: String): Result<Long> {
+        return createResult {
+            loginService.postLogin(LoginRequest(socialType = "kakao", socialId = socialId).toRequestBody()).data?.memberId ?: throw NoDataException()
+        }.onFailure { error ->
+            Timber.e("error : $error")
+        }
     }
 
     override fun hasToken(): Flow<Boolean> = dataStoreDataSource.hasToken()
 
-    override fun postSign(id: String, nickname: String, region: String): Flow<Int> = flow {
-        Timber.e("LoginRepositoryImpl start")
-        runCatching {
+    override suspend fun postSign(id: String, nickname: String, region: String): Result<Int> {
+        return createResult {
             loginService.postSignUp(
                 SignRequest(
                     socialType = "kakao",
@@ -45,17 +35,9 @@ class LoginRepositoryImpl @Inject constructor(
                     nickname = nickname,
                     region = region.toRegion().region
                 ).toRequestBody()
-            )
+            ).data ?: throw NoDataException()
+        }.onFailure { error ->
+            Timber.e("error : $error")
         }
-            .onSuccess { response ->
-                Timber.e("LoginRepositoryImpl Success $response")
-                response.data?.let {
-                    emit(it)
-                } ?: throw NoDataException()
-            }
-            .onFailure { error ->
-                Timber.e("LoginRepositoryImpl error : $error")
-                throwableError<Int>(error)
-            }
     }
 }

--- a/core/data/src/main/java/com/youthtalk/repository/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/youthtalk/repository/LoginRepositoryImpl.kt
@@ -16,28 +16,24 @@ class LoginRepositoryImpl @Inject constructor(
     private val loginService: LoginService,
     private val dataStoreDataSource: DataStoreDataSource
 ) : LoginRepository {
-    override suspend fun postLogin(socialId: String): Result<Long> {
-        return createResult {
-            loginService.postLogin(LoginRequest(socialType = "kakao", socialId = socialId).toRequestBody()).data?.memberId ?: throw NoDataException()
-        }.onFailure { error ->
-            Timber.e("error : $error")
-        }
+    override suspend fun postLogin(socialId: String): Result<Long> = createResult {
+        loginService.postLogin(LoginRequest(socialType = "kakao", socialId = socialId).toRequestBody()).data?.memberId ?: throw NoDataException()
+    }.onFailure { error ->
+        Timber.e("error : $error")
     }
 
     override fun hasToken(): Flow<Boolean> = dataStoreDataSource.hasToken()
 
-    override suspend fun postSign(id: String, nickname: String, region: String): Result<Int> {
-        return createResult {
-            loginService.postSignUp(
-                SignRequest(
-                    socialType = "kakao",
-                    socialId = id,
-                    nickname = nickname,
-                    region = region.toRegion().region
-                ).toRequestBody()
-            ).data ?: throw NoDataException()
-        }.onFailure { error ->
-            Timber.e("error : $error")
-        }
+    override suspend fun postSign(id: String, nickname: String, region: String): Result<Int> = createResult {
+        loginService.postSignUp(
+            SignRequest(
+                socialType = "kakao",
+                socialId = id,
+                nickname = nickname,
+                region = region.toRegion().region
+            ).toRequestBody()
+        ).data ?: throw NoDataException()
+    }.onFailure { error ->
+        Timber.e("error : $error")
     }
 }

--- a/core/data/src/main/java/com/youthtalk/utils/ErrorUtils.kt
+++ b/core/data/src/main/java/com/youthtalk/utils/ErrorUtils.kt
@@ -8,6 +8,7 @@ import com.core.exception.NotPermissionMethod
 import com.core.exception.UnAuthorizedException
 import com.youthtalk.dto.CommonResponse
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import retrofit2.HttpException
 import timber.log.Timber
 
@@ -48,7 +49,7 @@ object ErrorUtils {
 
     inline fun <reified T> mapToCustomException(it: HttpException): Exception {
         val error = it.response()?.errorBody()?.string() ?: throw InvalidValueException(it.message)
-        val response = Json.decodeFromString<CommonResponse<T>>(error)
+        val response = Json.decodeFromString<CommonResponse<JsonElement?>>(error)
         return when (it.code()) {
             401 -> UnAuthorizedException(response.message)
             404 -> NotFoundResource(response.message)

--- a/core/data/src/test/java/com/youthtalk/repository/LoginRepositoryTest.kt
+++ b/core/data/src/test/java/com/youthtalk/repository/LoginRepositoryTest.kt
@@ -1,14 +1,18 @@
 package com.youthtalk.repository
 
 import com.core.datastore.datasource.DataStoreDataSource
+import com.core.exception.BadRequestException
 import com.core.exception.UnAuthorizedException
 import com.youthtalk.data.LoginService
 import com.youthtalk.dto.CommonResponse
 import com.youthtalk.dto.MemberId
 import com.youthtalk.dto.login.LoginRequest
+import com.youthtalk.dto.login.SignRequest
 import com.youthtalk.dto.toResponseBody
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.InjectMocks
@@ -34,7 +38,7 @@ class LoginRepositoryTest {
 
     @Test
     fun givenSocialId_whenLogin_thenReturnsMemberId() {
-        runBlocking {
+        runTest {
             // given
             val socialId = "88888"
             val memberId = 23L
@@ -46,14 +50,14 @@ class LoginRepositoryTest {
             val result = sut.postLogin(socialId).getOrThrow()
 
             // then
-            Assert.assertEquals(memberId, result)
+            assertEquals(memberId, result)
             verify(loginService).postLogin(any())
         }
     }
 
     @Test
     fun givenWrongSocialId_whenLogin_thenThrowsNull() {
-        runBlocking {
+        runTest {
             // given
             val socialId = "xxxxxx"
             val memberId = null
@@ -77,6 +81,57 @@ class LoginRepositoryTest {
 
             // then
             verify(loginService).postLogin(any())
+        }
+    }
+
+    @Test
+    fun givenSignInfo_whenSignUp_thenReturnsMemberId() {
+        runTest {
+            val socialId = "666666"
+            val socialType = "kakao"
+            val nickname = "압도적도적"
+            val region = "서울"
+            val memberId = 23
+
+            val signUpRequest = SignRequest(socialType, socialId, nickname, region)
+            whenever(loginService.postSignUp(any())).thenReturn(CommonResponse(200, "요청에 성공하였습니다", "S01", memberId))
+
+            // when
+            val result = sut.postSign(socialId, nickname, region).getOrThrow()
+
+            // then
+            assertEquals(memberId, result)
+            verify(loginService).postSignUp(any())
+        }
+    }
+
+    @Test
+    fun givenWrongRegion_whenSignUp_thenThrows400Exception() {
+        runTest {
+            val socialId = "666666"
+            val socialType = "kakao"
+            val nickname = "압도적도적"
+            val region = "없는지역"
+            val memberId = 23
+
+            whenever(loginService.postSignUp(any())).thenThrow(
+                HttpException(
+                    Response.error<Any>(
+                        400,
+                        toResponseBody(CommonResponse<ArrayList<String>>(400, "유효하지 않은 값을 입력하였습니다.", "F01", arrayListOf("지역이 유효하지 않습니다.")))
+                    )
+                )
+            )
+
+            // when
+            Assert.assertThrows(BadRequestException::class.java) {
+                runBlocking {
+                    sut.postSign(socialId, nickname, region).getOrThrow()
+                }
+            }
+
+            // then
+            verify(loginService).postSignUp(any())
         }
     }
 }

--- a/core/data/src/test/java/com/youthtalk/repository/LoginRepositoryTest.kt
+++ b/core/data/src/test/java/com/youthtalk/repository/LoginRepositoryTest.kt
@@ -1,0 +1,82 @@
+package com.youthtalk.repository
+
+import com.core.datastore.datasource.DataStoreDataSource
+import com.core.exception.UnAuthorizedException
+import com.youthtalk.data.LoginService
+import com.youthtalk.dto.CommonResponse
+import com.youthtalk.dto.MemberId
+import com.youthtalk.dto.login.LoginRequest
+import com.youthtalk.dto.toResponseBody
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.HttpException
+import retrofit2.Response
+
+@RunWith(MockitoJUnitRunner::class)
+class LoginRepositoryTest {
+
+    @InjectMocks
+    private lateinit var sut: LoginRepositoryImpl
+
+    @Mock
+    private lateinit var loginService: LoginService
+
+    @Mock
+    private lateinit var dataStoreDataSource: DataStoreDataSource
+
+    @Test
+    fun givenSocialId_whenLogin_thenReturnsMemberId() {
+        runBlocking {
+            // given
+            val socialId = "88888"
+            val memberId = 23L
+            val loginRequest = LoginRequest(socialType = "kakao", socialId = socialId)
+
+            whenever(loginService.postLogin(any())).thenReturn(CommonResponse(200, "요청에 성공하였습니다", "S01", MemberId(memberId)))
+
+            // when
+            val result = sut.postLogin(socialId).getOrThrow()
+
+            // then
+            Assert.assertEquals(memberId, result)
+            verify(loginService).postLogin(any())
+        }
+    }
+
+    @Test
+    fun givenWrongSocialId_whenLogin_thenThrowsNull() {
+        runBlocking {
+            // given
+            val socialId = "xxxxxx"
+            val memberId = null
+            val loginRequest = LoginRequest(socialType = "kakao", socialId = socialId)
+
+            whenever(loginService.postLogin(any())).thenThrow(
+                HttpException(
+                    Response.error<Any>(
+                        401,
+                        toResponseBody(CommonResponse<Unit?>(401, "회원이 아닙니다.", "F01", memberId))
+                    )
+                )
+            )
+
+            // when
+            Assert.assertThrows(UnAuthorizedException::class.java) {
+                runBlocking {
+                    sut.postLogin(socialId).getOrThrow()
+                }
+            }
+
+            // then
+            verify(loginService).postLogin(any())
+        }
+    }
+}

--- a/core/dataApi/src/main/java/com/core/dataapi/repository/LoginRepository.kt
+++ b/core/dataApi/src/main/java/com/core/dataapi/repository/LoginRepository.kt
@@ -3,9 +3,9 @@ package com.core.dataapi.repository
 import kotlinx.coroutines.flow.Flow
 
 interface LoginRepository {
-    fun postLogin(socialId: String): Flow<Long>
+    suspend fun postLogin(socialId: String): Result<Long>
 
     fun hasToken(): Flow<Boolean>
 
-    fun postSign(id: String, nickname: String, region: String): Flow<Int>
+    suspend fun postSign(id: String, nickname: String, region: String): Result<Int>
 }

--- a/core/domain/src/main/java/com/core/domain/usercase/user/PostLoginUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/usercase/user/PostLoginUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class PostLoginUseCase @Inject constructor(
     private val loginRepository: LoginRepository
 ) {
-    operator fun invoke(socialId: String) = loginRepository.postLogin(socialId)
+    suspend operator fun invoke(socialId: String) = loginRepository.postLogin(socialId)
 }

--- a/core/domain/src/main/java/com/core/domain/usercase/user/PostSignUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/usercase/user/PostSignUseCase.kt
@@ -2,13 +2,14 @@ package com.core.domain.usercase.user
 
 import com.core.dataapi.repository.LoginRepository
 import javax.inject.Inject
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flatMapMerge
 
 class PostSignUseCase @Inject constructor(
     private val loginRepository: LoginRepository
 ) {
-    @OptIn(ExperimentalCoroutinesApi::class)
-    operator fun invoke(id: String, nickname: String, region: String) = loginRepository.postSign(id, nickname, region)
-        .flatMapMerge { loginRepository.postLogin(id) }
+    suspend operator fun invoke(id: String, nickname: String, region: String): Result<Long> {
+        val signResult = loginRepository.postSign(id, nickname, region)
+        if (signResult.isFailure) return Result.failure(signResult.exceptionOrNull()!!)
+
+        return loginRepository.postLogin(id)
+    }
 }

--- a/core/exception/src/main/java/com/core/exception/BadRequestException.kt
+++ b/core/exception/src/main/java/com/core/exception/BadRequestException.kt
@@ -1,5 +1,3 @@
 package com.core.exception
 
-class BadRequestException(
-    override val message: String?
-): RuntimeException()
+class BadRequestException(override val message: String?) : RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/BadRequestException.kt
+++ b/core/exception/src/main/java/com/core/exception/BadRequestException.kt
@@ -2,4 +2,4 @@ package com.core.exception
 
 class BadRequestException(
     override val message: String?
-): Exception()
+): RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/InvalidValueException.kt
+++ b/core/exception/src/main/java/com/core/exception/InvalidValueException.kt
@@ -2,7 +2,7 @@ package com.core.exception
 
 class InvalidValueException(
     private val m: String? = "InvalidValueException"
-): Exception() {
+): RuntimeException()  {
     override val message: String?
         get() = m
 }

--- a/core/exception/src/main/java/com/core/exception/InvalidValueException.kt
+++ b/core/exception/src/main/java/com/core/exception/InvalidValueException.kt
@@ -1,8 +1,3 @@
 package com.core.exception
 
-class InvalidValueException(
-    private val m: String? = "InvalidValueException"
-): RuntimeException()  {
-    override val message: String?
-        get() = m
-}
+class InvalidValueException(override val message: String? = "InvalidValueException") : RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/NetworkErrorException.kt
+++ b/core/exception/src/main/java/com/core/exception/NetworkErrorException.kt
@@ -1,8 +1,3 @@
 package com.core.exception
 
-class NetworkErrorException(
-    private val m: String? = "NetworkErrorException"
-) : RuntimeException() {
-    override val message: String?
-        get() = m
-}
+class NetworkErrorException(override val message: String? = "NetworkErrorException") : RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/NetworkErrorException.kt
+++ b/core/exception/src/main/java/com/core/exception/NetworkErrorException.kt
@@ -2,7 +2,7 @@ package com.core.exception
 
 class NetworkErrorException(
     private val m: String? = "NetworkErrorException"
-) : Exception() {
+) : RuntimeException() {
     override val message: String?
         get() = m
 }

--- a/core/exception/src/main/java/com/core/exception/NoDataException.kt
+++ b/core/exception/src/main/java/com/core/exception/NoDataException.kt
@@ -1,8 +1,3 @@
 package com.core.exception
 
-class NoDataException(
-    private val m: String? = "NoDataException"
-): RuntimeException()  {
-    override val message: String?
-        get() = m
-}
+class NoDataException(override val message: String? = "NoDataException") : RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/NoDataException.kt
+++ b/core/exception/src/main/java/com/core/exception/NoDataException.kt
@@ -2,7 +2,7 @@ package com.core.exception
 
 class NoDataException(
     private val m: String? = "NoDataException"
-): Exception() {
+): RuntimeException()  {
     override val message: String?
         get() = m
 }

--- a/core/exception/src/main/java/com/core/exception/NotFoundResource.kt
+++ b/core/exception/src/main/java/com/core/exception/NotFoundResource.kt
@@ -1,8 +1,3 @@
 package com.core.exception
 
-class NotFoundResource(
-    private val m: String? = "NotFoundResource"
-): RuntimeException()  {
-    override val message: String?
-    get() = m
-}
+class NotFoundResource(override val message: String? = "NotFoundResource") : RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/NotFoundResource.kt
+++ b/core/exception/src/main/java/com/core/exception/NotFoundResource.kt
@@ -2,7 +2,7 @@ package com.core.exception
 
 class NotFoundResource(
     private val m: String? = "NotFoundResource"
-): Exception() {
+): RuntimeException()  {
     override val message: String?
     get() = m
 }

--- a/core/exception/src/main/java/com/core/exception/NotPermissionMethod.kt
+++ b/core/exception/src/main/java/com/core/exception/NotPermissionMethod.kt
@@ -1,8 +1,3 @@
 package com.core.exception
 
-class NotPermissionMethod(
-    private val m: String? = "NotPermissionMethod"
-): RuntimeException()  {
-    override val message: String?
-    get() = m
-}
+class NotPermissionMethod(override val message: String? = "NotPermissionMethod") : RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/NotPermissionMethod.kt
+++ b/core/exception/src/main/java/com/core/exception/NotPermissionMethod.kt
@@ -2,7 +2,7 @@ package com.core.exception
 
 class NotPermissionMethod(
     private val m: String? = "NotPermissionMethod"
-): Exception() {
+): RuntimeException()  {
     override val message: String?
     get() = m
 }

--- a/core/exception/src/main/java/com/core/exception/UnAuthorizedException.kt
+++ b/core/exception/src/main/java/com/core/exception/UnAuthorizedException.kt
@@ -1,9 +1,3 @@
 package com.core.exception
 
-//401 에러 Exception
-class UnAuthorizedException(
-    private val errorMessage : String? = "UnAuthorizedException"
-) : RuntimeException() {
-    override val message: String?
-        get() = errorMessage
-}
+class UnAuthorizedException(override val message: String? = "UnAuthorizedException") : RuntimeException()

--- a/core/exception/src/main/java/com/core/exception/UnAuthorizedException.kt
+++ b/core/exception/src/main/java/com/core/exception/UnAuthorizedException.kt
@@ -3,7 +3,7 @@ package com.core.exception
 //401 에러 Exception
 class UnAuthorizedException(
     private val errorMessage : String? = "UnAuthorizedException"
-) : Exception() {
+) : RuntimeException() {
     override val message: String?
         get() = errorMessage
 }

--- a/feature/community/src/main/java/com/core/community/screen/detail/CommunityDetailScreen.kt
+++ b/feature/community/src/main/java/com/core/community/screen/detail/CommunityDetailScreen.kt
@@ -145,7 +145,7 @@ fun CommunityDetailScreen(
                 is CommunityDetailUiEffect.ShowSnackBarReportFail -> {
                     showSnackBar(it.message.toString())
                 }
-                
+
                 is CommunityDetailUiEffect.InitError -> {
                     showSnackBar(it.message)
                     onBack()
@@ -154,7 +154,6 @@ fun CommunityDetailScreen(
                     showSnackBar(context.getString(R.string.block_user_snackbar_message, it.userName))
                     onBack()
                 }
-
             }
         }
     }
@@ -259,7 +258,6 @@ fun CommunityDetailScreen(
             }
         )
     }
-
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/community/src/main/java/com/core/community/viewmodel/CommunityDetailViewModel.kt
+++ b/feature/community/src/main/java/com/core/community/viewmodel/CommunityDetailViewModel.kt
@@ -227,7 +227,7 @@ class CommunityDetailViewModel @Inject constructor(
                 }
         }
     }
-    
+
     private fun initData(postId: Long) {
         viewModelScope.launch {
             combine(

--- a/feature/login/src/main/java/com/core/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/core/login/LoginViewModel.kt
@@ -15,8 +15,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -60,32 +58,24 @@ class LoginViewModel @Inject constructor(
         socialId = "$userId"
         viewModelScope.launch {
             postLoginUseCase(socialId)
-                .catch {
-                    Timber.e("viewModel postLogin error $it")
-                    _error.emit(it)
-                }
-                .collectLatest {
+                .onSuccess {
                     uiEffect.emit(LoginUiEffect.GoMainActivity)
+                }.onFailure {
+                    _error.emit(it)
                 }
         }
     }
 
     fun postSign(nickname: String, region: String) {
-        Timber.e("postSign Start")
         viewModelScope.launch {
+            loading.value = true
             postSignUseCase(socialId, nickname, region)
-                .onStart {
-                    loading.value = true
-                }
-                .onCompletion {
+                .onSuccess {
                     loading.value = false
-                }
-                .catch {
-                    Timber.e("viewModel sign error $it")
-                    _error.emit(it)
-                }
-                .collectLatest {
                     uiEffect.emit(LoginUiEffect.GoMainActivity)
+                }.onFailure {
+                    loading.value = false
+                    _error.emit(it)
                 }
         }
     }

--- a/feature/login/src/main/java/com/core/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/core/login/LoginViewModel.kt
@@ -59,7 +59,7 @@ class LoginViewModel @Inject constructor(
     fun postLogin(userId: Long) {
         socialId = "$userId"
         viewModelScope.launch {
-            postLoginUseCase("950331")
+            postLoginUseCase(socialId)
                 .catch {
                     Timber.e("viewModel postLogin error $it")
                     _error.emit(it)


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
LoginRepository의 회원가입과 로그인 반환을 Flow가 아닌 Result 타입으로 변경
Flow를 사용하더라도 API에 직접적으로 연결되어있는게 아니기때문에
데이터가 변경될때마다 데이터를 다시 요청해야함(one-shot과 다를 바 없음)

createResult 에서 매핑하는 코드 수정
🧪 테스트 내역 (선택)
LoginRepositoryTest 작성
📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)

This closes #303 